### PR TITLE
This change allows a callback method to be entered as an option.  

### DIFF
--- a/js/jquery.iframe-auto-height.plugin.js
+++ b/js/jquery.iframe-auto-height.plugin.js
@@ -10,7 +10,7 @@
     $.fn.iframeAutoHeight = function (options) {
         // set default option values
         var options = $.extend({
-            heightOffset: 0
+            heightOffset: 0, callback: function(newHeight){}
         }, options);
 
         // iterate over the matched elements passed to the plugin
@@ -43,6 +43,7 @@
                 // Set inline style to equal the body height of the iframed content plus a little
                 var newHeight = iframe.contentWindow.document.body.offsetHeight + options.heightOffset;
                 iframe.style.height = newHeight + 'px';
+                options.callback({newFrameHeight:newHeight});
             }
 
         }); // end


### PR DESCRIPTION
This change allows a callback method to be entered as an option.  The new height is sent as the newFrameHeight property of the object returned to the callback method.  This allows, for instance, for a cross domain solution where an iframe resized from the inner domain can pass a message via a solution like easyXDM to an iframe in the outer domain.
