### PR TITLE
IE Quirks mode support.

### DIFF
--- a/js/jquery.iframe-auto-height.plugin.js
+++ b/js/jquery.iframe-auto-height.plugin.js
@@ -46,7 +46,13 @@
             // resizeHeight
             function resizeHeight(iframe) {
                 // Set inline style to equal the body height of the iframed content plus a little
-                var newHeight = iframe.contentWindow.document.body.offsetHeight + options.heightOffset;
+                var newHeight;
+                if(iframe.contentWindow.document.compatMode && 'ActiveXObject' in window && 'function' === typeof window.ActiveXObject) {
+                    // IE Quirks mode
+                    newHeight = iframe.contentWindow.document.body.scrollHeight + options.heightOffset;
+                } else {
+                    newHeight = iframe.contentWindow.document.body.offsetHeight + options.heightOffset;
+                }
                 iframe.style.height = newHeight + 'px';
                 options.callback({newFrameHeight:newHeight});
             }


### PR DESCRIPTION
If the iframe document is read in quirks mode, fixed a problem with IE not take the correct height.
(I'm not good at English, so I'm sorry if it is difficult for you to understand my English.)
