### PR TITLE
Hey, take a look at this fix for chrome / safari

### DIFF
--- a/js/jquery.iframe-auto-height.plugin.js
+++ b/js/jquery.iframe-auto-height.plugin.js
@@ -48,6 +48,8 @@
             function resizeHeight(iframe) {
                 // Set inline style to equal the body height of the iframed content plus a little
                 var newHeight;
+                // Webkit Fix: Reset iframe height to 0 to force new frame size to fit window properly
+                iframe.style.height = '0px';
                 if(iframe.contentWindow.document.compatMode && 'ActiveXObject' in window && 'function' === typeof window.ActiveXObject) {
                     // IE Quirks mode
                     newHeight = iframe.contentWindow.document.body.scrollHeight + options.heightOffset;


### PR DESCRIPTION
Height doesn't change if short content is loaded after tall content has been displayed

Simply force the iframe height to 0px, get new height, then set new height
