### PR TITLE
Rewrote iframe height calculation to use jQuery.height().

### DIFF
--- a/js/jquery.iframe-auto-height.plugin.js
+++ b/js/jquery.iframe-auto-height.plugin.js
@@ -55,12 +55,9 @@
       // resizeHeight
       function resizeHeight(iframe) {
         // Set inline style to equal the body height of the iframed content plus a little
-        var newHeight;
-        if (isQuirksMode(iframe)) {
-          newHeight = iframe.contentWindow.document.body.scrollHeight + options.heightOffset;
-        } else {
-          newHeight = iframe.contentWindow.document.body.offsetHeight + options.heightOffset;
-        }
+        var frameDoc = iframe.contentWindow.document;
+        var newHeight = Math.max($(frameDoc).height(), $(frameDoc.body).height()) + options.heightOffset;
+        
         debug("New Height: " + newHeight);
         iframe.style.height = newHeight + 'px';
         options.callback({newFrameHeight: newHeight});


### PR DESCRIPTION
Rewrote the height calculation to use jQuery.height() for more consistent cross browser values.
I'm not sure if it needs to check both the document height and the body height, so I added both to be sure.
