### PR TITLE
Rewrote iframe height calculation to use jQuery.height().

### DIFF
--- a/js/jquery.iframe-auto-height.plugin.js
+++ b/js/jquery.iframe-auto-height.plugin.js
@@ -38,21 +38,6 @@
 
     // iterate over the matched elements passed to the plugin
     $(this).each(function () {
-
-      function hasActiveX() {
-        return (typeof window.ActiveXObject !== "undefined");
-      }
-
-      // isQuirksMode
-      function isQuirksMode(iframe) {
-        if (iframe.contentWindow.document.compatMode && hasActiveX() && 'function' === typeof window.ActiveXObject) {
-          debug("IE Quirks mode");
-          return true;
-        }
-        // else
-        return false;
-      }      
-      
       // resizeHeight
       function resizeHeight(iframe) {
         // Reset iframe height to 0 to force new frame size to fit window properly


### PR DESCRIPTION
I rewrote the height calculation to use jQuery.height() for more consistent cross browser values and to simplify the code a little bit.  I squashed the previous bug in Firefox by resetting the iframe height to 0px before trying to get the document height.
