### PR TITLE
Fix bug that cannot work under Firefox 11.0

### DIFF
--- a/release/jquery.iframe-auto-height.js
+++ b/release/jquery.iframe-auto-height.js
@@ -76,6 +76,15 @@
         // get the iframe body height and set inline style to that plus a little
         var $body = $(iframe, window.top.document).contents().find('body');
         var newHeight = $body[0].scrollHeight + options.heightOffset;
+
+        // fix bugs for firefox 11
+        if ($.browser.mozilla) {
+          var originalOverflow = $body[0].style.overflow;
+          $body[0].style.overflow = "scroll";
+          newHeight = $body[0].scrollHeight + options.heightOffset;
+          $body[0].style.overflow = originalOverflow;
+        }
+
         debug(newHeight);
 
         if (newHeight < options.minHeight) {


### PR DESCRIPTION
Hi house9,

Thanks for your jquery plugin, it helps me a lot :)

The issue is, this plugin does not work in my Firefox 11.0. My iframe could only be resized to the minHeight which I have set at initializing. I found that the body height of the inner document will be "0" if its overflow is not "scroll" in firefox 11.0 (I didn't test other versions). Now I have fixed this issue, and it works for me.

Hope it is useful :)
