### PR TITLE
Fixed problem with window.top

### DIFF
--- a/release/jquery.iframe-auto-height.js
+++ b/release/jquery.iframe-auto-height.js
@@ -3,7 +3,7 @@
 
 /*
   Plugin: iframe autoheight jQuery Plugin
-  Version: 1.9.5
+  Version: 1.9.5 -patched
   Author and Contributors
   ========================================
   NATHAN SMITH (http://sonspring.com/)
@@ -19,6 +19,7 @@
   Jens Bissinger (https://github.com/dpree)
   jbreton (https://github.com/jbreton)
   mindmelting (https://github.com/mindmelting)
+  CapitalId (https://github.com/CapitalID)
 
   File: jquery.iframe-auto-height.plugin.js
   Remarks: original code from http://sonspring.com/journal/jquery-iframe-sizing
@@ -64,7 +65,7 @@
     function showDiagnostics(iframe, calledFrom) {
       debug("Diagnostics from '" + calledFrom + "'");
       try {
-        debug("  " + $(iframe, window.top.document).contents().find('body')[0].scrollHeight + " for ...find('body')[0].scrollHeight");
+        debug("  " + $(iframe, window.parent).contents().find('body')[0].scrollHeight + " for ...find('body')[0].scrollHeight");
         debug("  " + $(iframe.contentWindow.document).height() + " for ...contentWindow.document).height()");
         debug("  " + $(iframe.contentWindow.document.body).height() + " for ...contentWindow.document.body).height()");
       } catch (ex) {
@@ -136,7 +137,7 @@
         }
 
         // get the iframe body height and set inline style to that plus a little
-        var $body = $(iframe, window.top.document).contents().find('body');
+        var $body = $(iframe, window.parent).contents().find('body');
         var strategy = findStrategy($.browser);
         var newHeight = strategy(iframe, $body, options, $.browser);
         debug(newHeight);

--- a/release/jquery.iframe-auto-height.js
+++ b/release/jquery.iframe-auto-height.js
@@ -3,7 +3,7 @@
 
 /*
   Plugin: iframe autoheight jQuery Plugin
-  Version: 1.9.5
+  Version: 1.9.5 - patched
   Author and Contributors
   ========================================
   NATHAN SMITH (http://sonspring.com/)
@@ -19,6 +19,7 @@
   Jens Bissinger (https://github.com/dpree)
   jbreton (https://github.com/jbreton)
   mindmelting (https://github.com/mindmelting)
+  CapitalId (https://github.com/CapitalID)
 
   File: jquery.iframe-auto-height.plugin.js
   Remarks: original code from http://sonspring.com/journal/jquery-iframe-sizing
@@ -27,198 +28,195 @@
 
 */
 (function ($) {
-  $.fn.iframeAutoHeight = function (spec) {
+	$.fn.iframeAutoHeight = function (spec) {
+		var undef;
+		if ($.browser === undef) {
+			var message = [];
+			message.push("WARNING: you appear to be using a newer version of jquery which does not support the $.browser variable.");
+			message.push("The jQuery iframe auto height plugin relies heavly on the $.browser features.");
+			message.push("Install jquery-browser: https://raw.github.com/house9/jquery-iframe-auto-height/master/release/jquery.browser.js");
+			alert(message.join("\n"));
+			return $;
+		}
 
-    var undef;
-    if ($.browser === undef) {
-      var message = [];
-      message.push("WARNING: you appear to be using a newer version of jquery which does not support the $.browser variable.");
-      message.push("The jQuery iframe auto height plugin relies heavly on the $.browser features.");
-      message.push("Install jquery-browser: https://raw.github.com/house9/jquery-iframe-auto-height/master/release/jquery.browser.js");
-      alert(message.join("\n"));
-      return $;
-    }
+		// set default option values
+		var options = $.extend({
+			heightOffset: 0,
+			minHeight: 0,
+			maxHeight: 0,
+			callback: function (newHeight) { },
+			animate: false,
+			debug: false,
+			diagnostics: false, // used for development only
+			resetToMinHeight: false,
+			triggerFunctions: [],
+			heightCalculationOverrides: []
+		}, spec);
 
-    // set default option values
-    var options = $.extend({
-        heightOffset: 0,
-        minHeight: 0,
-        maxHeight: 0,
-        callback: function (newHeight) {},
-        animate: false,
-        debug: false,
-        diagnostics: false, // used for development only
-        resetToMinHeight: false,
-        triggerFunctions: [],
-        heightCalculationOverrides: []
-      }, spec);
+		// logging
+		function debug(message) {
+			if (options.debug && options.debug === true && window.console) {
+				console.log(message);
+			}
+		}
 
-    // logging
-    function debug(message) {
-      if (options.debug && options.debug === true && window.console) {
-        console.log(message);
-      }
-    }
+		// not used by production code
+		function showDiagnostics(iframe, calledFrom) {
+			debug("Diagnostics from '" + calledFrom + "'");
+			try {
+				debug("  " + $(iframe, window.parent).contents().find('body')[0].scrollHeight + " for ...find('body')[0].scrollHeight");
+				debug("  " + $(iframe.contentWindow.document).height() + " for ...contentWindow.document).height()");
+				debug("  " + $(iframe.contentWindow.document.body).height() + " for ...contentWindow.document.body).height()");
+			} catch (ex) {
+				// ie fails when called during for each, ok later on
+				// probably not an issue if called in a document ready block
+				debug("  unable to check in this state");
+			}
+			debug("End diagnostics -> results vary by browser and when diagnostics are requested");
+		}
 
-    // not used by production code
-    function showDiagnostics(iframe, calledFrom) {
-      debug("Diagnostics from '" + calledFrom + "'");
-      try {
-        debug("  " + $(iframe, window.top.document).contents().find('body')[0].scrollHeight + " for ...find('body')[0].scrollHeight");
-        debug("  " + $(iframe.contentWindow.document).height() + " for ...contentWindow.document).height()");
-        debug("  " + $(iframe.contentWindow.document.body).height() + " for ...contentWindow.document.body).height()");
-      } catch (ex) {
-        // ie fails when called during for each, ok later on
-        // probably not an issue if called in a document ready block
-        debug("  unable to check in this state");
-      }
-      debug("End diagnostics -> results vary by browser and when diagnostics are requested");
-    }
+		// show all option values
+		debug(options);
 
-    // show all option values
-    debug(options);
+		// ******************************************************
+		// iterate over the matched elements passed to the plugin ; return will make it chainable
+		return this.each(function () {
+			// ******************************************************
+			// http://api.jquery.com/jQuery.browser/
+			var strategyKeys = ['webkit', 'mozilla', 'msie', 'opera'];
+			var strategies = {};
+			strategies['default'] = function (iframe, $iframeBody, options, browser) {
+				// NOTE: this is how the plugin determines the iframe height, override if you need custom
+				return $iframeBody[0].scrollHeight + options.heightOffset;
+			};
 
-    // ******************************************************
-    // iterate over the matched elements passed to the plugin ; return will make it chainable
-    return this.each(function () {
+			jQuery.each(strategyKeys, function (index, value) {
+				// use the default strategy for all browsers, can be overridden if desired
+				strategies[value] = strategies['default'];
+			});
 
-      // ******************************************************
-      // http://api.jquery.com/jQuery.browser/
-      var strategyKeys = ['webkit', 'mozilla', 'msie', 'opera'];
-      var strategies = {};
-      strategies['default'] = function (iframe, $iframeBody, options, browser) {
-        // NOTE: this is how the plugin determines the iframe height, override if you need custom
-        return $iframeBody[0].scrollHeight + options.heightOffset;
-      };
+			// override strategies if registered in options
+			jQuery.each(options.heightCalculationOverrides, function (index, value) {
+				strategies[value.browser] = value.calculation;
+			});
 
-      jQuery.each(strategyKeys, function (index, value) {
-        // use the default strategy for all browsers, can be overridden if desired
-        strategies[value] = strategies['default'];
-      });
+			function findStrategy(browser) {
+				var strategy = null;
 
-      // override strategies if registered in options
-      jQuery.each(options.heightCalculationOverrides, function (index, value) {
-        strategies[value.browser] = value.calculation;
-      });
+				jQuery.each(strategyKeys, function (index, value) {
+					if (browser[value]) {
+						strategy = strategies[value];
+						return false;
+					}
+				});
 
-      function findStrategy(browser) {
-        var strategy = null;
+				if (strategy === null) {
+					strategy = strategies['default'];
+				}
 
-        jQuery.each(strategyKeys, function (index, value) {
-          if (browser[value]) {
-            strategy = strategies[value];
-            return false;
-          }
-        });
+				return strategy;
+			}
+			// ******************************************************
 
-        if (strategy === null) {
-          strategy = strategies['default'];
-        }
+			// for use by webkit only
+			var loadCounter = 0;
 
-        return strategy;
-      }
-      // ******************************************************
+			var iframeDoc = this.contentDocument || this.contentWindow.document;
 
-      // for use by webkit only
-      var loadCounter = 0;
+			// resizeHeight
+			function resizeHeight(iframe) {
+				if (options.diagnostics) {
+					showDiagnostics(iframe, "resizeHeight");
+				}
 
-      var iframeDoc = this.contentDocument || this.contentWindow.document;
+				// set the iframe size to minHeight so it'll get smaller on resizes in FF and IE
+				if (options.resetToMinHeight && options.resetToMinHeight === true) {
+					iframe.style.height = options.minHeight + 'px';
+				}
 
-      // resizeHeight
-      function resizeHeight(iframe) {
-        if (options.diagnostics) {
-          showDiagnostics(iframe, "resizeHeight");
-        }
+				// get the iframe body height and set inline style to that plus a little
+				var $body = $(iframe, window.parent).contents().find('body');
+				var strategy = findStrategy($.browser);
+				var newHeight = strategy(iframe, $body, options, $.browser);
+				debug(newHeight);
 
-        // set the iframe size to minHeight so it'll get smaller on resizes in FF and IE
-        if (options.resetToMinHeight && options.resetToMinHeight === true) {
-          iframe.style.height = options.minHeight + 'px';
-        }
+				if (newHeight < options.minHeight) {
+					debug("new height is less than minHeight");
+					newHeight = options.minHeight;
+				}
 
-        // get the iframe body height and set inline style to that plus a little
-        var $body = $(iframe, window.top.document).contents().find('body');
-        var strategy = findStrategy($.browser);
-        var newHeight = strategy(iframe, $body, options, $.browser);
-        debug(newHeight);
+				if (options.maxHeight > 0 && newHeight > options.maxHeight) {
+					debug("new height is greater than maxHeight");
+					newHeight = options.maxHeight;
+				}
 
-        if (newHeight < options.minHeight) {
-          debug("new height is less than minHeight");
-          newHeight = options.minHeight;
-        }
+				newHeight += options.heightOffset;
 
-        if (options.maxHeight > 0 && newHeight > options.maxHeight) {
-          debug("new height is greater than maxHeight");
-          newHeight = options.maxHeight;
-        }
+				debug("New Height: " + newHeight);
+				if (options.animate) {
+					$(iframe).animate({ height: newHeight + 'px' }, { duration: 500 });
+				} else {
+					iframe.style.height = newHeight + 'px';
+				}
 
-        newHeight += options.heightOffset;
+				options.callback.apply($(iframe), [{ newFrameHeight: newHeight }]);
+			} // END resizeHeight
 
-        debug("New Height: " + newHeight);
-        if (options.animate) {
-          $(iframe).animate({height: newHeight + 'px'}, {duration: 500});
-        } else {
-          iframe.style.height = newHeight + 'px';
-        }
+			// debug me
+			debug(this);
+			if (options.diagnostics) {
+				showDiagnostics(this, "each iframe");
+			}
 
-        options.callback.apply($(iframe), [{newFrameHeight: newHeight}]);
-      } // END resizeHeight
+			// if trigger functions are registered, invoke them
+			if (options.triggerFunctions.length > 0) {
+				debug(options.triggerFunctions.length + " trigger Functions");
+				for (var i = 0; i < options.triggerFunctions.length; i++) {
+					options.triggerFunctions[i](resizeHeight, this);
+				}
+			}
 
-      // debug me
-      debug(this);
-      if (options.diagnostics) {
-        showDiagnostics(this, "each iframe");
-      }
+			// Check if browser is Webkit (Safari/Chrome) or Opera
+			if ($.browser.webkit || $.browser.opera || $.browser.chrome) {
+				debug("browser is webkit or opera");
 
-      // if trigger functions are registered, invoke them
-      if (options.triggerFunctions.length > 0) {
-        debug(options.triggerFunctions.length + " trigger Functions");
-        for (var i = 0; i < options.triggerFunctions.length; i++) {
-          options.triggerFunctions[i](resizeHeight, this);
-        }
-      }
+				// Start timer when loaded.
+				$(this).load(function () {
+					var delay = 0;
+					var iframe = this;
 
-      // Check if browser is Webkit (Safari/Chrome) or Opera
-      if ($.browser.webkit || $.browser.opera || $.browser.chrome) {
-        debug("browser is webkit or opera");
+					var delayedResize = function () {
+						resizeHeight(iframe);
+					};
 
-        // Start timer when loaded.
-        $(this).load(function () {
-          var delay = 0;
-          var iframe = this;
+					if (loadCounter === 0) {
+						// delay the first one
+						delay = 500;
+					} else {
+						// Reset iframe height to 0 to force new frame size to fit window properly
+						// this is only an issue when going from large to small iframe, not executed on page load
+						iframe.style.height = options.minHeight + 'px';
+					}
 
-          var delayedResize = function () {
-            resizeHeight(iframe);
-          };
+					debug("load delay: " + delay);
+					setTimeout(delayedResize, delay);
+					loadCounter++;
+				});
 
-          if (loadCounter === 0) {
-            // delay the first one
-            delay = 500;
-          } else {
-            // Reset iframe height to 0 to force new frame size to fit window properly
-            // this is only an issue when going from large to small iframe, not executed on page load
-            iframe.style.height = options.minHeight + 'px';
-          }
-
-          debug("load delay: " + delay);
-          setTimeout(delayedResize, delay);
-          loadCounter++;
-        });
-
-        // Safari and Opera need a kick-start.
-        var source = $(this).attr('src');
-        $(this).attr('src', '');
-        $(this).attr('src', source);
-      } else {
-        // For other browsers.
-        if(iframeDoc.readyState  === 'complete') {
-          resizeHeight(this);
-        } else {
-          $(this).load(function () {
-            resizeHeight(this);
-          });
-        }
-      } // if browser
-
-    }); // $(this).each(function () {
-  }; // $.fn.iframeAutoHeight = function (options) {
+				// Safari and Opera need a kick-start.
+				var source = $(this).attr('src');
+				$(this).attr('src', '');
+				$(this).attr('src', source);
+			} else {
+				// For other browsers.
+				if (iframeDoc.readyState === 'complete') {
+					resizeHeight(this);
+				} else {
+					$(this).load(function () {
+						resizeHeight(this);
+					});
+				}
+			} // if browser
+		}); // $(this).each(function () {
+	}; // $.fn.iframeAutoHeight = function (options) {
 }(jQuery)); // (function ($) {

--- a/release/jquery.iframe-auto-height.js
+++ b/release/jquery.iframe-auto-height.js
@@ -3,7 +3,7 @@
 
 /*
   Plugin: iframe autoheight jQuery Plugin
-  Version: 1.9.5 - patched
+  Version: 1.9.5
   Author and Contributors
   ========================================
   NATHAN SMITH (http://sonspring.com/)
@@ -19,7 +19,6 @@
   Jens Bissinger (https://github.com/dpree)
   jbreton (https://github.com/jbreton)
   mindmelting (https://github.com/mindmelting)
-  CapitalId (https://github.com/CapitalID)
 
   File: jquery.iframe-auto-height.plugin.js
   Remarks: original code from http://sonspring.com/journal/jquery-iframe-sizing
@@ -28,195 +27,198 @@
 
 */
 (function ($) {
-	$.fn.iframeAutoHeight = function (spec) {
-		var undef;
-		if ($.browser === undef) {
-			var message = [];
-			message.push("WARNING: you appear to be using a newer version of jquery which does not support the $.browser variable.");
-			message.push("The jQuery iframe auto height plugin relies heavly on the $.browser features.");
-			message.push("Install jquery-browser: https://raw.github.com/house9/jquery-iframe-auto-height/master/release/jquery.browser.js");
-			alert(message.join("\n"));
-			return $;
-		}
+  $.fn.iframeAutoHeight = function (spec) {
 
-		// set default option values
-		var options = $.extend({
-			heightOffset: 0,
-			minHeight: 0,
-			maxHeight: 0,
-			callback: function (newHeight) { },
-			animate: false,
-			debug: false,
-			diagnostics: false, // used for development only
-			resetToMinHeight: false,
-			triggerFunctions: [],
-			heightCalculationOverrides: []
-		}, spec);
+    var undef;
+    if ($.browser === undef) {
+      var message = [];
+      message.push("WARNING: you appear to be using a newer version of jquery which does not support the $.browser variable.");
+      message.push("The jQuery iframe auto height plugin relies heavly on the $.browser features.");
+      message.push("Install jquery-browser: https://raw.github.com/house9/jquery-iframe-auto-height/master/release/jquery.browser.js");
+      alert(message.join("\n"));
+      return $;
+    }
 
-		// logging
-		function debug(message) {
-			if (options.debug && options.debug === true && window.console) {
-				console.log(message);
-			}
-		}
+    // set default option values
+    var options = $.extend({
+        heightOffset: 0,
+        minHeight: 0,
+        maxHeight: 0,
+        callback: function (newHeight) {},
+        animate: false,
+        debug: false,
+        diagnostics: false, // used for development only
+        resetToMinHeight: false,
+        triggerFunctions: [],
+        heightCalculationOverrides: []
+      }, spec);
 
-		// not used by production code
-		function showDiagnostics(iframe, calledFrom) {
-			debug("Diagnostics from '" + calledFrom + "'");
-			try {
-				debug("  " + $(iframe, window.parent).contents().find('body')[0].scrollHeight + " for ...find('body')[0].scrollHeight");
-				debug("  " + $(iframe.contentWindow.document).height() + " for ...contentWindow.document).height()");
-				debug("  " + $(iframe.contentWindow.document.body).height() + " for ...contentWindow.document.body).height()");
-			} catch (ex) {
-				// ie fails when called during for each, ok later on
-				// probably not an issue if called in a document ready block
-				debug("  unable to check in this state");
-			}
-			debug("End diagnostics -> results vary by browser and when diagnostics are requested");
-		}
+    // logging
+    function debug(message) {
+      if (options.debug && options.debug === true && window.console) {
+        console.log(message);
+      }
+    }
 
-		// show all option values
-		debug(options);
+    // not used by production code
+    function showDiagnostics(iframe, calledFrom) {
+      debug("Diagnostics from '" + calledFrom + "'");
+      try {
+        debug("  " + $(iframe, window.top.document).contents().find('body')[0].scrollHeight + " for ...find('body')[0].scrollHeight");
+        debug("  " + $(iframe.contentWindow.document).height() + " for ...contentWindow.document).height()");
+        debug("  " + $(iframe.contentWindow.document.body).height() + " for ...contentWindow.document.body).height()");
+      } catch (ex) {
+        // ie fails when called during for each, ok later on
+        // probably not an issue if called in a document ready block
+        debug("  unable to check in this state");
+      }
+      debug("End diagnostics -> results vary by browser and when diagnostics are requested");
+    }
 
-		// ******************************************************
-		// iterate over the matched elements passed to the plugin ; return will make it chainable
-		return this.each(function () {
-			// ******************************************************
-			// http://api.jquery.com/jQuery.browser/
-			var strategyKeys = ['webkit', 'mozilla', 'msie', 'opera'];
-			var strategies = {};
-			strategies['default'] = function (iframe, $iframeBody, options, browser) {
-				// NOTE: this is how the plugin determines the iframe height, override if you need custom
-				return $iframeBody[0].scrollHeight + options.heightOffset;
-			};
+    // show all option values
+    debug(options);
 
-			jQuery.each(strategyKeys, function (index, value) {
-				// use the default strategy for all browsers, can be overridden if desired
-				strategies[value] = strategies['default'];
-			});
+    // ******************************************************
+    // iterate over the matched elements passed to the plugin ; return will make it chainable
+    return this.each(function () {
 
-			// override strategies if registered in options
-			jQuery.each(options.heightCalculationOverrides, function (index, value) {
-				strategies[value.browser] = value.calculation;
-			});
+      // ******************************************************
+      // http://api.jquery.com/jQuery.browser/
+      var strategyKeys = ['webkit', 'mozilla', 'msie', 'opera'];
+      var strategies = {};
+      strategies['default'] = function (iframe, $iframeBody, options, browser) {
+        // NOTE: this is how the plugin determines the iframe height, override if you need custom
+        return $iframeBody[0].scrollHeight + options.heightOffset;
+      };
 
-			function findStrategy(browser) {
-				var strategy = null;
+      jQuery.each(strategyKeys, function (index, value) {
+        // use the default strategy for all browsers, can be overridden if desired
+        strategies[value] = strategies['default'];
+      });
 
-				jQuery.each(strategyKeys, function (index, value) {
-					if (browser[value]) {
-						strategy = strategies[value];
-						return false;
-					}
-				});
+      // override strategies if registered in options
+      jQuery.each(options.heightCalculationOverrides, function (index, value) {
+        strategies[value.browser] = value.calculation;
+      });
 
-				if (strategy === null) {
-					strategy = strategies['default'];
-				}
+      function findStrategy(browser) {
+        var strategy = null;
 
-				return strategy;
-			}
-			// ******************************************************
+        jQuery.each(strategyKeys, function (index, value) {
+          if (browser[value]) {
+            strategy = strategies[value];
+            return false;
+          }
+        });
 
-			// for use by webkit only
-			var loadCounter = 0;
+        if (strategy === null) {
+          strategy = strategies['default'];
+        }
 
-			var iframeDoc = this.contentDocument || this.contentWindow.document;
+        return strategy;
+      }
+      // ******************************************************
 
-			// resizeHeight
-			function resizeHeight(iframe) {
-				if (options.diagnostics) {
-					showDiagnostics(iframe, "resizeHeight");
-				}
+      // for use by webkit only
+      var loadCounter = 0;
 
-				// set the iframe size to minHeight so it'll get smaller on resizes in FF and IE
-				if (options.resetToMinHeight && options.resetToMinHeight === true) {
-					iframe.style.height = options.minHeight + 'px';
-				}
+      var iframeDoc = this.contentDocument || this.contentWindow.document;
 
-				// get the iframe body height and set inline style to that plus a little
-				var $body = $(iframe, window.parent).contents().find('body');
-				var strategy = findStrategy($.browser);
-				var newHeight = strategy(iframe, $body, options, $.browser);
-				debug(newHeight);
+      // resizeHeight
+      function resizeHeight(iframe) {
+        if (options.diagnostics) {
+          showDiagnostics(iframe, "resizeHeight");
+        }
 
-				if (newHeight < options.minHeight) {
-					debug("new height is less than minHeight");
-					newHeight = options.minHeight;
-				}
+        // set the iframe size to minHeight so it'll get smaller on resizes in FF and IE
+        if (options.resetToMinHeight && options.resetToMinHeight === true) {
+          iframe.style.height = options.minHeight + 'px';
+        }
 
-				if (options.maxHeight > 0 && newHeight > options.maxHeight) {
-					debug("new height is greater than maxHeight");
-					newHeight = options.maxHeight;
-				}
+        // get the iframe body height and set inline style to that plus a little
+        var $body = $(iframe, window.top.document).contents().find('body');
+        var strategy = findStrategy($.browser);
+        var newHeight = strategy(iframe, $body, options, $.browser);
+        debug(newHeight);
 
-				newHeight += options.heightOffset;
+        if (newHeight < options.minHeight) {
+          debug("new height is less than minHeight");
+          newHeight = options.minHeight;
+        }
 
-				debug("New Height: " + newHeight);
-				if (options.animate) {
-					$(iframe).animate({ height: newHeight + 'px' }, { duration: 500 });
-				} else {
-					iframe.style.height = newHeight + 'px';
-				}
+        if (options.maxHeight > 0 && newHeight > options.maxHeight) {
+          debug("new height is greater than maxHeight");
+          newHeight = options.maxHeight;
+        }
 
-				options.callback.apply($(iframe), [{ newFrameHeight: newHeight }]);
-			} // END resizeHeight
+        newHeight += options.heightOffset;
 
-			// debug me
-			debug(this);
-			if (options.diagnostics) {
-				showDiagnostics(this, "each iframe");
-			}
+        debug("New Height: " + newHeight);
+        if (options.animate) {
+          $(iframe).animate({height: newHeight + 'px'}, {duration: 500});
+        } else {
+          iframe.style.height = newHeight + 'px';
+        }
 
-			// if trigger functions are registered, invoke them
-			if (options.triggerFunctions.length > 0) {
-				debug(options.triggerFunctions.length + " trigger Functions");
-				for (var i = 0; i < options.triggerFunctions.length; i++) {
-					options.triggerFunctions[i](resizeHeight, this);
-				}
-			}
+        options.callback.apply($(iframe), [{newFrameHeight: newHeight}]);
+      } // END resizeHeight
 
-			// Check if browser is Webkit (Safari/Chrome) or Opera
-			if ($.browser.webkit || $.browser.opera || $.browser.chrome) {
-				debug("browser is webkit or opera");
+      // debug me
+      debug(this);
+      if (options.diagnostics) {
+        showDiagnostics(this, "each iframe");
+      }
 
-				// Start timer when loaded.
-				$(this).load(function () {
-					var delay = 0;
-					var iframe = this;
+      // if trigger functions are registered, invoke them
+      if (options.triggerFunctions.length > 0) {
+        debug(options.triggerFunctions.length + " trigger Functions");
+        for (var i = 0; i < options.triggerFunctions.length; i++) {
+          options.triggerFunctions[i](resizeHeight, this);
+        }
+      }
 
-					var delayedResize = function () {
-						resizeHeight(iframe);
-					};
+      // Check if browser is Webkit (Safari/Chrome) or Opera
+      if ($.browser.webkit || $.browser.opera || $.browser.chrome) {
+        debug("browser is webkit or opera");
 
-					if (loadCounter === 0) {
-						// delay the first one
-						delay = 500;
-					} else {
-						// Reset iframe height to 0 to force new frame size to fit window properly
-						// this is only an issue when going from large to small iframe, not executed on page load
-						iframe.style.height = options.minHeight + 'px';
-					}
+        // Start timer when loaded.
+        $(this).load(function () {
+          var delay = 0;
+          var iframe = this;
 
-					debug("load delay: " + delay);
-					setTimeout(delayedResize, delay);
-					loadCounter++;
-				});
+          var delayedResize = function () {
+            resizeHeight(iframe);
+          };
 
-				// Safari and Opera need a kick-start.
-				var source = $(this).attr('src');
-				$(this).attr('src', '');
-				$(this).attr('src', source);
-			} else {
-				// For other browsers.
-				if (iframeDoc.readyState === 'complete') {
-					resizeHeight(this);
-				} else {
-					$(this).load(function () {
-						resizeHeight(this);
-					});
-				}
-			} // if browser
-		}); // $(this).each(function () {
-	}; // $.fn.iframeAutoHeight = function (options) {
+          if (loadCounter === 0) {
+            // delay the first one
+            delay = 500;
+          } else {
+            // Reset iframe height to 0 to force new frame size to fit window properly
+            // this is only an issue when going from large to small iframe, not executed on page load
+            iframe.style.height = options.minHeight + 'px';
+          }
+
+          debug("load delay: " + delay);
+          setTimeout(delayedResize, delay);
+          loadCounter++;
+        });
+
+        // Safari and Opera need a kick-start.
+        var source = $(this).attr('src');
+        $(this).attr('src', '');
+        $(this).attr('src', source);
+      } else {
+        // For other browsers.
+        if(iframeDoc.readyState  === 'complete') {
+          resizeHeight(this);
+        } else {
+          $(this).load(function () {
+            resizeHeight(this);
+          });
+        }
+      } // if browser
+
+    }); // $(this).each(function () {
+  }; // $.fn.iframeAutoHeight = function (options) {
 }(jQuery)); // (function ($) {


### PR DESCRIPTION
When the iframe parent is framed by another application, the domains do not match. This causes the plugin to fail. Solution: use window.parent instead of window.top.